### PR TITLE
feat: store per-user web3.storage tokens in localstorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ At a high level, the app works like this:
 
 A [`Forum` smart contract][src-forum-sol] is deployed to an Ethereum network, which allows creating posts, commenting on them, and voting on posts and comments.
 
-### 
+### Items
 
 Posts and comments are represented internally as `Item` structs:
 

--- a/packages/webapp/src/api/context.tsx
+++ b/packages/webapp/src/api/context.tsx
@@ -1,14 +1,20 @@
 import React, { useEffect, useState } from 'react'
+import { Web3Storage } from 'web3.storage'
+
 import { useChainContext } from '../chain/context';
-import { getStorageClient } from '../storage';
+import { useWeb3StorageToken } from '../utils/hooks';
 import { ForumAPI } from './forum';
 
 interface ApiContextInterface {
-    api: ForumAPI | undefined
+    api: ForumAPI | undefined,
+    storageToken: string,
+    setStorageToken: (token: string) => void,
 }
 
 const ApiContext = React.createContext<ApiContextInterface>({
     api: undefined,
+    storageToken: '',
+    setStorageToken: () => {},
 })
 
 export function useApiContext() {
@@ -17,7 +23,7 @@ export function useApiContext() {
 
 export function ApiContextProvider(props: { children: React.ReactNode }) {
     const { readonlyContract, authorizedContract } = useChainContext()
-    const storage = getStorageClient()
+    const [ storageToken, setStorageToken ] = useWeb3StorageToken()
 
     const [api, setApi] = useState<ForumAPI | undefined>(undefined)
 
@@ -26,13 +32,14 @@ export function ApiContextProvider(props: { children: React.ReactNode }) {
             setApi(undefined)
             return
         }
+        const storage = storageToken ? new Web3Storage({ token: storageToken }) : undefined
         const forumAPI = new ForumAPI({ storage, readonlyContract, authorizedContract })
         console.log('setting new forum api instance', forumAPI)
         setApi(forumAPI)
-    }, [readonlyContract, authorizedContract])
+    }, [readonlyContract, authorizedContract, storageToken])
 
 
-    const context = { api }
+    const context = { api, storageToken, setStorageToken }
     return (
         <ApiContext.Provider value={context}>
             {props.children}

--- a/packages/webapp/src/components/AccountSettings/accountsettings.module.css
+++ b/packages/webapp/src/components/AccountSettings/accountsettings.module.css
@@ -1,0 +1,16 @@
+
+
+.container {
+  margin: 10px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.container input {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  min-width: 600px;
+}
+

--- a/packages/webapp/src/components/AccountSettings/index.tsx
+++ b/packages/webapp/src/components/AccountSettings/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { Redirect } from 'react-router';
+import { useApiContext } from '../../api/context';
+import { useChainContext } from '../../chain/context';
+import Layout from "../Layout";
+import styles from './accountsettings.module.css'
+
+export default function AccountSettings() {
+  const { loggedIn } = useChainContext()
+  const { storageToken, setStorageToken } = useApiContext()
+
+  if (!loggedIn) {
+    return <Redirect to='/login' />
+  }
+
+  const noTokenMessage = (
+    <span>
+      Your account does not have a storage token set. To submit posts or comments, you'll need to
+      sign up for a free account at <a href="https://web3.storage">Web3.Storage</a>, then paste your
+      API token here:
+    </span>
+  )
+
+  const tokenMessage = (
+    <span>
+      Your Web3.Storage token is displayed below. To remove it (and your ability to post), remove the text in the box or press the delete button.
+    </span>
+  )
+
+  const deleteButton = <button type='button' onClick={() => setStorageToken('')}>Delete token</button>
+
+  const tokenInput = (
+    <div className={styles.container} >
+      {storageToken ? tokenMessage : noTokenMessage}
+
+      <input value={storageToken} onChange={(e) => setStorageToken(e.target.value)} />
+
+      {storageToken ? deleteButton : undefined}
+    </div>
+  )
+
+  return (
+    <Layout>
+      {tokenInput}
+    </Layout>
+  )
+}

--- a/packages/webapp/src/components/App/index.tsx
+++ b/packages/webapp/src/components/App/index.tsx
@@ -9,6 +9,7 @@ import Login from '../Login'
 import Logout from '../Logout'
 import Home from '../Home'
 import About from "../About";
+import AccountSettings from "../AccountSettings";
 
 import { ChainContextProvider } from '../../chain/context';
 import { useEagerConnect, useReadonlyConnection } from "../../chain/hooks";
@@ -40,6 +41,9 @@ function Routes() {
     </Route>
     <Route path='/items/:itemId'>
       <ItemDetails />
+    </Route>
+    <Route path='/account'>
+      <AccountSettings />
     </Route>
   </Switch>
 }

--- a/packages/webapp/src/components/Header/index.tsx
+++ b/packages/webapp/src/components/Header/index.tsx
@@ -1,5 +1,4 @@
 import { ethers } from 'ethers'
-import { useState } from 'react'
 import { useQuery, useQueryClient } from 'react-query'
 import { Link } from 'react-router-dom'
 import { NETWORK_NAME } from '../../chain/constants'
@@ -14,7 +13,6 @@ const Account = () => {
   const { account, library } = authorized
 
   const queryClient = useQueryClient()
-  const [faucetUsed, setFaucetUsed] = useState(false)
 
   const balanceKey = ['account', 'balance', account]
   const balanceQuery = useQuery(balanceKey, async () => {
@@ -49,10 +47,10 @@ const Account = () => {
 
   return (
     <>
-      <span>Account&nbsp;</span>
-      <span>
-        {accountDisplayName(account)}
-      </span>
+      <Link to='/account'>
+        <span>Account&nbsp;</span>
+        <span>{accountDisplayName(account)}</span>
+      </Link>
       <span>&nbsp;|&nbsp;</span>
       {balance && <span>Balance: {balance}&nbsp;|&nbsp;</span>}
       {showFaucetButton && <span>{faucetButton}&nbsp;|&nbsp;</span>}

--- a/packages/webapp/src/components/ItemDetails/index.tsx
+++ b/packages/webapp/src/components/ItemDetails/index.tsx
@@ -75,6 +75,12 @@ export default function ItemDetails() {
     </div>
   )
 
+  const noTokenMessage = (
+    <div className={styles.loggedOutMessage}>
+      <Link to="/account">Add a storage token to your account to comment</Link>
+    </div>
+  )
+
   return (
     <Layout>
       <div className={styles.container}>
@@ -86,7 +92,10 @@ export default function ItemDetails() {
           {item && item.content && item.content.body}
         </div>
 
-        {loggedIn ? commentForm : loggedOutMessage}
+        {loggedIn 
+          ? (api.canPost ? commentForm : noTokenMessage)
+          : loggedOutMessage
+        }
 
         {item && <CommentList api={api} parentItem={item} />}
       </div>

--- a/packages/webapp/src/components/Submit/index.tsx
+++ b/packages/webapp/src/components/Submit/index.tsx
@@ -23,6 +23,9 @@ export default function Submit() {
       </div>
   }
   
+  if (!api.canPost) {
+    return <Redirect to='/account' />
+  }
 
   const submitForm = (e: React.FormEvent) => {
     e.preventDefault()

--- a/packages/webapp/src/utils/hooks.ts
+++ b/packages/webapp/src/utils/hooks.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+
+// from https://usehooks.com/useLocalStorage/
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue] as const;
+}
+
+
+const KEY_W3S_TOKEN = 'web3.storage-token'
+
+export function useWeb3StorageToken() {
+  return useLocalStorage(KEY_W3S_TOKEN, '')
+}


### PR DESCRIPTION
This adds a basic "account" page where you can paste in a web3.storage token, and some error handling to redirect to that page when trying to post without a token.

Also changes the `#getJson` method in `ForumAPI` to fetch from the dweb.link gateway, so we can still have read-only functionality even if we don't have a client instance.
